### PR TITLE
Updates and Bug Fixes

### DIFF
--- a/capeditor/blocks.py
+++ b/capeditor/blocks.py
@@ -15,6 +15,7 @@ from wagtailmodelchooser.blocks import ModelChooserBlock
 
 from .forms.fields import PolygonField, MultiPolygonField, BoundaryMultiPolygonField, PolygonOrMultiPolygonField
 from .forms.widgets import CircleWidget
+from .serializers import parse_tz
 from .utils import file_path_mime
 
 
@@ -115,9 +116,9 @@ class AlertReferenceStructValue(StructValue):
     @property
     def ref_alert_identifier(self):
         alert_page = self.get("ref_alert").specific
-
-        if hasattr(alert_page, "cap_reference_id"):
-            return alert_page.cap_reference_id
+        if hasattr(alert_page, "sender") and hasattr(alert_page, "identifier") and hasattr(alert_page, "sent"):
+            sent = parse_tz(alert_page.sent.isoformat())
+            return "{},{},{}".format(alert_page.sender, alert_page.identifier, sent)
 
         return None
 

--- a/capeditor/cap_settings.py
+++ b/capeditor/cap_settings.py
@@ -115,7 +115,8 @@ class PredefinedAlertArea(Orderable):
 
     panels = [
         FieldPanel("name"),
-        FieldPanel("geom", widget=PolygonDrawWidget(attrs={"resize_trigger_class": "map-resize-trigger"})),
+        FieldPanel("geom",
+                   widget=PolygonDrawWidget(attrs={"resize_trigger_selector": ".w-tabs__tab.map-resize-trigger"})),
     ]
 
 

--- a/capeditor/models.py
+++ b/capeditor/models.py
@@ -97,8 +97,19 @@ class CapAlertPageForm(WagtailAdminPageForm):
         if msgType and msgType != 'Alert':
             references = cleaned_data.get("references")
             if not references:
+                # if the message type is not 'Alert' then references are required
                 self.add_error('references', _("You must select at least one reference alert for this message type. "
                                                "Only 'Alert' Message Type can be saved without references."))
+            else:
+                alerts_ids = []
+                for reference in references:
+                    ref_alert_page = reference.value.get("ref_alert").specific
+                    if ref_alert_page:
+                        alerts_ids.append(ref_alert_page.identifier)
+
+                # check if the same alert is selected more than once
+                if len(alerts_ids) != len(set(alerts_ids)):
+                    self.add_error('references', _("You cannot select the same alert more than once."))
 
         return cleaned_data
 

--- a/capeditor/models.py
+++ b/capeditor/models.py
@@ -90,6 +90,18 @@ class CapAlertPageForm(WagtailAdminPageForm):
                         info_field.block.child_blocks[block_type].child_blocks[field_name].name = name
                         info_field.block.child_blocks[block_type].child_blocks[field_name].label = label
 
+    def clean(self):
+        cleaned_data = super().clean()
+        msgType = cleaned_data.get("msgType")
+
+        if msgType and msgType != 'Alert':
+            references = cleaned_data.get("references")
+            if not references:
+                self.add_error('references', _("You must select at least one reference alert for this message type. "
+                                               "Only 'Alert' Message Type can be saved without references."))
+
+        return cleaned_data
+
 
 class AbstractCapAlertPage(Page):
     base_form_class = CapAlertPageForm

--- a/capeditor/models.py
+++ b/capeditor/models.py
@@ -92,8 +92,9 @@ class CapAlertPageForm(WagtailAdminPageForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        msgType = cleaned_data.get("msgType")
 
+        # validata msgType
+        msgType = cleaned_data.get("msgType")
         if msgType and msgType != 'Alert':
             references = cleaned_data.get("references")
             if not references:
@@ -110,6 +111,24 @@ class CapAlertPageForm(WagtailAdminPageForm):
                 # check if the same alert is selected more than once
                 if len(alerts_ids) != len(set(alerts_ids)):
                     self.add_error('references', _("You cannot select the same alert more than once."))
+
+        # validate dates
+        sent = cleaned_data.get("sent")
+        alert_infos = cleaned_data.get("info")
+        if alert_infos:
+            for info in alert_infos:
+                effective = info.value.get("effective")
+                onset = info.value.get("onset")
+                expires = info.value.get("expires")
+
+                if effective and sent and effective < sent:
+                    self.add_error('info', _("Effective date cannot be earlier than the alert sent date."))
+
+                if onset and sent and onset < sent:
+                    self.add_error('info', _("Onset date cannot be earlier than the alert sent date."))
+
+                if expires and sent and expires < sent:
+                    self.add_error('info', _("Expires date cannot be earlier than the alert sent date."))
 
         return cleaned_data
 

--- a/capeditor/static/capeditor/js/widget/boundary-polygon-widget.js
+++ b/capeditor/static/capeditor/js/widget/boundary-polygon-widget.js
@@ -108,6 +108,7 @@ BoundaryPolygonWidget.prototype.initMap = async function () {
         container: this.options.map_id,
         style: defaultStyle,
         doubleClickZoom: false,
+        scrollZoom: false,
     });
 
 

--- a/capeditor/static/capeditor/js/widget/boundary-polygon-widget.js
+++ b/capeditor/static/capeditor/js/widget/boundary-polygon-widget.js
@@ -290,7 +290,14 @@ BoundaryPolygonWidget.prototype.addAdminBoundaryLayer = function () {
                     if (name) {
                         this.areaDescInput.val(name)
                     }
-                    this.setSourceData(feature)
+
+                    const truncatedFeature = turf.truncate(feature, {
+                        precision: 2,
+                        coordinates: 2,
+                        mutate: true
+                    })
+
+                    this.setSourceData(truncatedFeature)
                 })
             }
         }

--- a/capeditor/static/capeditor/js/widget/circle-widget.js
+++ b/capeditor/static/capeditor/js/widget/circle-widget.js
@@ -277,8 +277,6 @@ CircleWidget.prototype.setSourceData = function (feature) {
 CircleWidget.prototype.initFromState = function () {
     const circeValue = this.getState()
 
-    console.log(circeValue)
-
     if (circeValue) {
         const {lon, lat, radius} = this.parseCircleValue(circeValue) || {}
 

--- a/capeditor/static/capeditor/js/widget/circle-widget.js
+++ b/capeditor/static/capeditor/js/widget/circle-widget.js
@@ -129,6 +129,7 @@ CircleWidget.prototype.initMap = async function () {
         container: this.options.map_id,
         style: defaultStyle,
         doubleClickZoom: false,
+        scrollZoom: false,
     });
 
 

--- a/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
+++ b/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
@@ -83,6 +83,7 @@ class PolygonDrawWidget {
             container: this.options.map_id,
             style: defaultStyle,
             doubleClickZoom: false,
+            scrollZoom: false,
         });
 
 

--- a/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
+++ b/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
@@ -10,8 +10,8 @@ class PolygonDrawWidget {
         this.geomInput = document.getElementById(this.options.id)
 
 
-        if (this.options.resize_trigger_class) {
-            this.resizeTriggerEls = document.getElementsByClassName(this.options.resize_trigger_class)
+        if (this.options.resize_trigger_selector) {
+            this.resizeTriggerEls = document.querySelectorAll(this.options.resize_trigger_selector)
         }
 
         this.initalValue = this.geomInput.value
@@ -19,7 +19,6 @@ class PolygonDrawWidget {
 
         this.createMap().then((map) => {
             this.map = map;
-
             this.fitBounds()
 
             if (this.resizeTriggerEls && this.resizeTriggerEls.length > 0) {
@@ -30,7 +29,6 @@ class PolygonDrawWidget {
                     })
                 }
             }
-
 
             this.initDraw();
         });

--- a/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
+++ b/capeditor/static/capeditor/js/widget/polygon-draw-widget.js
@@ -138,7 +138,6 @@ class PolygonDrawWidget {
 
     initDraw() {
         const feature = this.getValue()
-
         this.draw = new MapboxDraw({
             displayControlsDefault: false,
             controls: {
@@ -173,7 +172,14 @@ class PolygonDrawWidget {
         if (combinedFeatures) {
             const feature = combinedFeatures.features[0]
 
-            this.setValue(JSON.stringify(feature.geometry))
+
+            const truncatedFeature = turf.truncate(feature, {
+                precision: 2,
+                coordinates: 2,
+                mutate: true
+            })
+
+            this.setValue(JSON.stringify(truncatedFeature.geometry))
 
         } else {
             this.setValue("")

--- a/capeditor/static/capeditor/js/widget/polygon-widget.js
+++ b/capeditor/static/capeditor/js/widget/polygon-widget.js
@@ -162,6 +162,7 @@ PolygonWidget.prototype.initMap = async function () {
         container: this.options.map_id,
         style: defaultStyle,
         doubleClickZoom: false,
+        scrollZoom: false,
     });
 
 

--- a/capeditor/static/capeditor/js/widget/polygon-widget.js
+++ b/capeditor/static/capeditor/js/widget/polygon-widget.js
@@ -323,8 +323,16 @@ PolygonWidget.prototype.clearDraw = function () {
 }
 
 
-PolygonWidget.prototype.setDrawData = function (geometry) {
-    if (geometry) {
+PolygonWidget.prototype.setDrawData = function (featureGeom) {
+    if (featureGeom) {
+
+        // truncate geometry
+        const geometry = turf.truncate(featureGeom, {
+            precision: 2,
+            coordinates: 2,
+            mutate: true
+        })
+
         const bbox = turf.bbox(geometry)
         const bounds = [[bbox[0], bbox[1]], [bbox[2], bbox[3]]]
 

--- a/capeditor/templates/capeditor/widgets/polygon_draw_widget.html
+++ b/capeditor/templates/capeditor/widgets/polygon_draw_widget.html
@@ -13,7 +13,7 @@
                 map_id: '{{ id }}_map',
                 map_srid: {{ map_srid|unlocalize }},
                 name: '{{ name }}',
-                resize_trigger_class: '{{ resize_trigger_class }}',
+                resize_trigger_selector: '{{ resize_trigger_selector }}',
             };
         {% endblock %}
         var {{ module }} =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = capeditor
-version = 0.5.3
+version = 0.5.4
 description = Wagtail based CAP composer
 long_description = file:README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
- Format referenced alerts as per CAP specification to be included in CAP XML
- Show errors if non Alert msgType is added without reference alerts
- Truncate area geo feature coordinates to 2 decimal places
- For reference alerts, check if the same alert is selected more than once
- Validate alert dates. Sent date, effective, onset and expiry dates
- Disable scrollZoom on map draw widgets
- Fix predefined area map drawing widgets resizing triggers