### PR TITLE
Add Contributor Covenant code of conduct (CODE_OF_CONDUCT.md)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the CAP Composer community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, colour, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behaviour that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behaviour include:
+
+- The use of sexualised language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies within all community spaces of this project, including GitHub issues, pull requests, discussions, code review comments and commit messages, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event, such as a training or workshop organised around this software.
+
+## Enforcement Responsibilities
+
+The maintainers of this repository, the WMO Regional Office for Africa (wmo-raf), are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+Maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported through any of the following channels:
+
+1. **Privately to the maintainers:** contact any repository maintainer listed on the [wmo-raf organisation page](https://github.com/wmo-raf) through a private GitHub message or the contact channels published at [climtech.africa](https://climtech.africa). Reports may be made in English, French or Portuguese.
+2. **GitHub's built-in reporting:** use the **Report content** option on any issue, pull request or comment, which notifies both the repository maintainers and GitHub. See [Reporting abuse or spam](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).
+3. **Blocking:** contributors may also protect themselves directly by [blocking a user from their account](https://docs.github.com/en/communities/maintaining-your-safety-on-github/blocking-a-user-from-your-personal-account); maintainers can additionally block users from the organisation and lock or restrict conversations on the repository.
+
+All complaints will be reviewed and investigated promptly and fairly. Maintainers will acknowledge a report within 5 working days.
+
+All maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behaviour deemed unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from maintainers, providing clarity around the nature of the violation and an explanation of why the behaviour was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of actions.
+
+**Consequence:** A warning with consequences for continued behaviour. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact:** A serious violation of community standards, including sustained inappropriate behaviour.
+
+**Consequence:** A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact:** Demonstrating a pattern of violation of community standards, including sustained inappropriate behaviour, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).


### PR DESCRIPTION
## Why

The Digital Public Goods Alliance (DPGA) review of CAP Composer noted, for Indicator 9C (Protection from harassment), that GitHub issues and pull requests count as contributor interaction and asked for a CODE_OF_CONDUCT.md at the repository root.

## What it contains

- Contributor Covenant 2.1 pledge, standards and scope (issues, PRs, discussions, reviews, and representing the project at trainings/workshops).
- A **Reporting** section with three channels: private contact with the wmo-raf maintainers, GitHub's built-in *Report content* tool, and user blocking. Reports accepted in English, French or Portuguese; acknowledgement within 5 working days.
- The standard four-step enforcement ladder (correction, warning, temporary ban, permanent ban).

## Note for maintainers

No public email address is published anywhere in the wmo-raf repositories, so the reporting section relies on GitHub channels and the climtech.africa contact page. If you prefer a dedicated address (for example the public email given to the DPGA, climatetechhub@gmail.com), add it to the *Reporting* section before merging.

The same file could be copied to the climweb and adl repositories: climweb's existing CODE_OF_CONDUCT.md has an empty contact placeholder in its Enforcement section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)